### PR TITLE
fix: order 생성 시, user 데이터를 통한 point 적립

### DIFF
--- a/scripts/seeds/grade/grade.seed.ts
+++ b/scripts/seeds/grade/grade.seed.ts
@@ -8,7 +8,7 @@ export const gradeData = [
   {
     id: 'grade_green',
     name: 'Green',
-    rate: 0,
+    rate: 1,
     minAmount: 0,
   },
   {

--- a/src/features/order/order.repository.ts
+++ b/src/features/order/order.repository.ts
@@ -128,6 +128,28 @@ export class OrderRepository {
     });
   }
 
+  async findGradeByUserId(tx: Prisma.TransactionClient, userId: string) {
+    const user = await tx.user.findUnique({
+      where: { id: userId },
+      select: {
+        grade: {
+          select: {
+            rate: true,
+          },
+        },
+      },
+    });
+
+    return user?.grade?.rate ?? 0;
+  }
+
+  async incrementPoints(tx: Prisma.TransactionClient, userId: string, points: number) {
+    await tx.user.update({
+      where: { id: userId },
+      data: { points: { increment: points } },
+    });
+  }
+
   async deleteOrder(
     tx: Prisma.TransactionClient,
     order: Order & { orderItems: OrderItem[]; payment: Payment | null },


### PR DESCRIPTION
## 📌 Related Issue

- #75

## 🧾 작업 사항

- user의 grade 내 rate 비율과 subtotal을 계산하여 포인트를 계산하여 order 생성 내, 저장할 수 있도록 수정

## 📚 리뷰 포인트

- 

## 📷 Screenshot/GIF

-
<img width="1920" height="1032" alt="스크린샷 2025-12-29 130746" src="https://github.com/user-attachments/assets/f812cbcc-1492-4482-9f28-e4d2ce49dfc6" />
<img width="1920" height="1032" alt="스크린샷 2025-12-29 130803" src="https://github.com/user-attachments/assets/d091ed1b-37ad-45e8-bed8-e19e63197367" />
