### PR TITLE
fix: 카트 조회 시 카트가 존재하지 않는다면 카트 생성

### DIFF
--- a/src/features/cart/cart.repository.ts
+++ b/src/features/cart/cart.repository.ts
@@ -16,9 +16,11 @@ export class CartRepository {
     });
   }
 
-  async findCart(userId: string) {
-    return prisma.cart.findUnique({
+  async upsertCart(userId: string) {
+    return prisma.cart.upsert({
       where: { buyerId: userId },
+      update: {},
+      create: { buyerId: userId },
       include: {
         items: {
           include: {

--- a/src/features/cart/cart.service.ts
+++ b/src/features/cart/cart.service.ts
@@ -23,20 +23,9 @@ export class CartService {
   }
 
   async getCart(userId: string) {
-    const cart = await this.cartRepository.findCart(userId);
+    const cart = await this.cartRepository.upsertCart(userId);
 
-    if (cart) {
-      return toCartResponseDtoWithItems(cart);
-    }
-
-    const newCart = await this.cartRepository.createCart(userId);
-
-    const emptyCartWithItems = {
-      ...newCart,
-      items: [],
-    };
-
-    return toCartResponseDtoWithItems(emptyCartWithItems);
+    return toCartResponseDtoWithItems(cart);
   }
 
   async updateCart(userId: string, body: CartItemBody) {


### PR DESCRIPTION
## 📌 Related Issue

- #80 

## 🧾 작업 사항

-카트 조회 시 카트가 존재하지 않는다면 카트 생성하도록 로직 변경

## 📚 리뷰 포인트

-

## 📷 Screenshot/GIF

-
