### PR TITLE
bugfix: 83

### DIFF
--- a/prisma/migrations/20251230001718_add_total_amount_for_grade/migration.sql
+++ b/prisma/migrations/20251230001718_add_total_amount_for_grade/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "totalAmount" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,7 @@ model User {
   refreshToken String?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
+  totalAmount  Int      @default(0)
 
   grade          Grade?         @relation(fields: [gradeId], references: [id], onDelete: SetNull)
   store          Store?

--- a/src/features/order/order.repository.ts
+++ b/src/features/order/order.repository.ts
@@ -150,6 +150,26 @@ export class OrderRepository {
     });
   }
 
+  async incrementAmount(tx: Prisma.TransactionClient, userId: string, amount: number) {
+    const user = await tx.user.update({
+      where: { id: userId },
+      data: { totalAmount: { increment: amount } },
+      select: { totalAmount: true, gradeId: true },
+    });
+
+    return {
+      totalAmount: user.totalAmount,
+      gradeId: user.gradeId!,
+    };
+  }
+
+  async updateGradeByUserId(tx: Prisma.TransactionClient, userId: string, gradeId: string) {
+    await tx.user.update({
+      where: { id: userId },
+      data: { gradeId: gradeId },
+    });
+  }
+
   async deleteOrder(
     tx: Prisma.TransactionClient,
     order: Order & { orderItems: OrderItem[]; payment: Payment | null },


### PR DESCRIPTION
## 📌 Related Issue

- #83 

## 🧾 작업 사항

- user table 에 totalAmount column을 생성하여 따로 총 구매량을 저장하도록 만들고 order 생성 시, 마다 totalAmount가 갱신되면서 totalAmount의 값을 각 grade값과 대조하여 갱신할 수 있도록 수정함

## 📚 리뷰 포인트

- gradeService를 orderService에서 사용할 수 있도록 수정했음.

## 📷 Screenshot/GIF

-
<img width="1920" height="1032" alt="스크린샷 2025-12-30 125811" src="https://github.com/user-attachments/assets/8e2aa2bf-9580-48f0-a2b6-c9dfbea7cd8b" />
<img width="1920" height="1032" alt="스크린샷 2025-12-30 125834" src="https://github.com/user-attachments/assets/2aa9bbb1-8c1e-4a54-ae70-2ac07d7abe43" />


