### PR TITLE
bugfix: 130

### DIFF
--- a/src/features/order/order.service.ts
+++ b/src/features/order/order.service.ts
@@ -140,9 +140,11 @@ export class OrderService {
           });
         }
 
+        const usePoint = dto.usePoint || 0;
+
         const rate = await this.orderRepository.findGradeByUserId(tx, userId);
 
-        const earnedPoints = Math.floor(subtotal * (rate / 100));
+        const earnedPoints = Math.floor((subtotal - usePoint) * (rate / 100));
 
         await this.orderRepository.incrementPoints(tx, userId, earnedPoints);
 


### PR DESCRIPTION
## 📌 Related Issue

- #130 

## 🧾 작업 사항

- point 가 있을 경우 response에 적립 point에 출력되는 subtotal를 계산할 때, 적용되서 처리할 수 있도록 수정함

## 📚 리뷰 포인트

-

## 📷 Screenshot/GIF

- 
<img width="1920" height="1032" alt="스크린샷 2026-01-05 151527" src="https://github.com/user-attachments/assets/4edd95d4-a5fc-4de2-b1ff-d9539d933626" />
<img width="1920" height="1032" alt="스크린샷 2026-01-05 151542" src="https://github.com/user-attachments/assets/bd68a8c6-b31c-4523-bce2-33cee35f480c" />
<img width="1920" height="1032" alt="스크린샷 2026-01-05 151623" src="https://github.com/user-attachments/assets/26260e9a-fafa-4af8-9455-a3247da456ac" />
<img width="1920" height="1032" alt="스크린샷 2026-01-05 151632" src="https://github.com/user-attachments/assets/b27bbdeb-a6ef-41f1-8570-a2fde1c76cd4" />


