### PR TITLE
test: dashboard & order (int)

### DIFF
--- a/src/features/order/order.schema.ts
+++ b/src/features/order/order.schema.ts
@@ -31,7 +31,7 @@ export const orderItemSchema = z.object({
 export const createOrderBodySchema = z.object({
   name: z.string().min(1),
   phone: z.string().regex(/^\d{6,7}-\d{4}$/, {
-    message: '하이픈(-)을 포함하여 7~8자리 번호를 입력해주세요. (예: 1234-5678)',
+    message: '하이픈(-)을 포함하여 전화번호를 입력해주세요. (예: 0101234-5678)',
   }),
   address: z.string().min(1),
   orderItems: z.array(orderItemSchema).min(1),
@@ -41,7 +41,7 @@ export const createOrderBodySchema = z.object({
 export const updateOrderBodySchema = z.object({
   name: z.string().min(1),
   phone: z.string().regex(/^\d{6,7}-\d{4}$/, {
-    message: '하이픈(-)을 포함하여 7~8자리 번호를 입력해주세요. (예: 1234-5678)',
+    message: '하이픈(-)을 포함하여 전화번호를 입력해주세요. (예: 0101234-5678)',
   }),
   address: z.string().min(1),
   orderItems: z.array(orderItemSchema).min(1),

--- a/tests/integration/dashboard.scenario.test.ts
+++ b/tests/integration/dashboard.scenario.test.ts
@@ -1,0 +1,250 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import request from 'supertest';
+import { app } from '../../src/app';
+import { clearDatabase, disconnectDatabase, ensureGradeExists } from '../helpers/test-db';
+import prisma from '../../src/lib/prisma';
+
+/**
+ * 시나리오: 대시보드 조회 테스트
+ *
+ * 1. 판매자 회원가입 & 로그인
+ *    POST /api/users
+ *    POST /api/auth/login
+ *
+ * 2. 판매자가 스토어 & 상품 생성 (DB 직접)
+ *
+ * 3. 구매자 회원가입 & 주문 생성 (DB 직접)
+ *
+ * 4. 판매자가 대시보드 조회
+ *    GET /api/dashboard
+ *
+ * 5. 구매자가 대시보드 조회 시도 (403 에러)
+ */
+describe('대시보드 조회 시나리오', () => {
+  let sellerToken: string;
+  let buyerToken: string;
+  let sellerId: string;
+  let buyerId: string;
+  let storeId: string;
+  let productId: string;
+  let sizeId: number;
+
+  beforeAll(async () => {
+    await clearDatabase();
+    await ensureGradeExists();
+
+    // 1. 판매자 회원가입 & 로그인
+    const sellerSignupRes = await request(app).post('/api/users').send({
+      email: 'seller@test.com',
+      password: 'TestPassword123!',
+      name: '판매자',
+      type: 'SELLER',
+    });
+    sellerId = sellerSignupRes.body.id;
+
+    const sellerLoginRes = await request(app).post('/api/auth/login').send({
+      email: 'seller@test.com',
+      password: 'TestPassword123!',
+    });
+    sellerToken = sellerLoginRes.body.accessToken;
+
+    // 2. 판매자가 스토어 & 상품 생성 (DB 직접)
+    const store = await prisma.store.create({
+      data: {
+        name: '대시보드 테스트 스토어',
+        address: '서울시 강남구',
+        phoneNumber: '02-1234-5678',
+        content: '대시보드 테스트용 스토어입니다',
+        userId: sellerId,
+      },
+    });
+    storeId = store.id;
+
+    // Size 생성 또는 가져오기
+    let size = await prisma.size.findFirst({
+      where: { en: 'XL' },
+    });
+    if (!size) {
+      size = await prisma.size.create({
+        data: { en: 'XL', ko: 'XL' },
+      });
+    }
+    sizeId = size.id;
+
+    const product = await prisma.product.create({
+      data: {
+        name: '대시보드 테스트 상품',
+        content: '대시보드 테스트용 상품입니다',
+        price: 100000,
+        categoryName: 'OUTER',
+        storeId: storeId,
+        image: 'https://fake-s3-url.com/product.jpg',
+      },
+    });
+    productId = product.id;
+
+    // 재고 생성
+    await prisma.stock.create({
+      data: {
+        productId: productId,
+        sizeId: sizeId,
+        quantity: 200,
+      },
+    });
+
+    // 3. 구매자 회원가입
+    const buyerSignupRes = await request(app).post('/api/users').send({
+      email: 'buyer@test.com',
+      password: 'TestPassword123!',
+      name: '구매자',
+      type: 'BUYER',
+    });
+    buyerId = buyerSignupRes.body.id;
+
+    const buyerLoginRes = await request(app).post('/api/auth/login').send({
+      email: 'buyer@test.com',
+      password: 'TestPassword123!',
+    });
+    buyerToken = buyerLoginRes.body.accessToken;
+
+    // 주문 생성 (DB 직접)
+    const order = await prisma.order.create({
+      data: {
+        name: '구매자',
+        phoneNumber: '0101234-5678',
+        address: '서울시 강남구',
+        subtotal: 200000,
+        totalQuantity: 2,
+        usePoint: 0,
+        buyerId: buyerId,
+      },
+    });
+
+    await prisma.orderItem.create({
+      data: {
+        orderId: order.id,
+        productId: productId,
+        productName: '대시보드 테스트 상품',
+        productImage: 'https://fake-s3-url.com/product.jpg',
+        sizeId: sizeId,
+        price: 100000,
+        quantity: 2,
+        storeId: storeId,
+      },
+    });
+
+    await prisma.payment.create({
+      data: {
+        orderId: order.id,
+        price: 200000,
+        status: 'CompletedPayment',
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await clearDatabase();
+    await disconnectDatabase();
+  });
+
+  it('판매자가 대시보드 조회', async () => {
+    // 4. 판매자가 대시보드 조회
+    const dashboardRes = await request(app)
+      .get('/api/dashboard')
+      .set('Authorization', `Bearer ${sellerToken}`);
+
+    expect(dashboardRes.status).toBe(200);
+    expect(dashboardRes.body).toHaveProperty('today');
+    expect(dashboardRes.body).toHaveProperty('week');
+    expect(dashboardRes.body).toHaveProperty('month');
+    expect(dashboardRes.body).toHaveProperty('year');
+    expect(dashboardRes.body).toHaveProperty('topSales');
+    expect(dashboardRes.body).toHaveProperty('priceRange');
+
+    // today 구조 검증
+    expect(dashboardRes.body.today).toHaveProperty('current');
+    expect(dashboardRes.body.today).toHaveProperty('previous');
+    expect(dashboardRes.body.today).toHaveProperty('changeRate');
+    expect(dashboardRes.body.today.current).toHaveProperty('totalOrders');
+    expect(dashboardRes.body.today.current).toHaveProperty('totalSales');
+
+    // topSales 구조 검증
+    expect(Array.isArray(dashboardRes.body.topSales)).toBe(true);
+
+    // priceRange 구조 검증
+    expect(Array.isArray(dashboardRes.body.priceRange)).toBe(true);
+  });
+
+  it('구매자가 대시보드 조회 시도 시 403 에러', async () => {
+    // 5. 구매자가 대시보드 조회 시도 (403 에러)
+    const res = await request(app)
+      .get('/api/dashboard')
+      .set('Authorization', `Bearer ${buyerToken}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toContain('판매자만');
+  });
+
+  it('인증 없이 대시보드 조회 시도 시 401 에러', async () => {
+    const res = await request(app).get('/api/dashboard');
+
+    expect(res.status).toBe(401);
+  });
+
+  it('대시보드 데이터에 year 통계가 올바르게 계산됨', async () => {
+    const dashboardRes = await request(app)
+      .get('/api/dashboard')
+      .set('Authorization', `Bearer ${sellerToken}`);
+
+    expect(dashboardRes.status).toBe(200);
+
+    // year 데이터 검증
+    const yearData = dashboardRes.body.year;
+    expect(yearData).toBeDefined();
+    expect(yearData.current).toHaveProperty('totalOrders');
+    expect(yearData.current).toHaveProperty('totalSales');
+
+    // 생성한 주문이 year 통계에 포함되어야 함
+    expect(yearData.current.totalOrders).toBeGreaterThanOrEqual(1);
+    expect(yearData.current.totalSales).toBeGreaterThanOrEqual(200000);
+  });
+
+  it('대시보드 priceRange가 올바르게 계산됨', async () => {
+    const dashboardRes = await request(app)
+      .get('/api/dashboard')
+      .set('Authorization', `Bearer ${sellerToken}`);
+
+    expect(dashboardRes.status).toBe(200);
+
+    const priceRange = dashboardRes.body.priceRange;
+    expect(Array.isArray(priceRange)).toBe(true);
+
+    // priceRange 항목 검증
+    priceRange.forEach((range: any) => {
+      expect(range).toHaveProperty('priceRange');
+      expect(range).toHaveProperty('totalSales');
+      expect(range).toHaveProperty('percentage');
+      expect(typeof range.percentage).toBe('number');
+    });
+  });
+
+  it('대시보드 topSales가 올바르게 계산됨', async () => {
+    const dashboardRes = await request(app)
+      .get('/api/dashboard')
+      .set('Authorization', `Bearer ${sellerToken}`);
+
+    expect(dashboardRes.status).toBe(200);
+
+    const topSales = dashboardRes.body.topSales;
+    expect(Array.isArray(topSales)).toBe(true);
+
+    // topSales 항목 검증
+    topSales.forEach((item: any) => {
+      expect(item).toHaveProperty('totalOrders');
+      expect(item).toHaveProperty('product');
+      expect(item.product).toHaveProperty('id');
+      expect(item.product).toHaveProperty('name');
+      expect(item.product).toHaveProperty('price');
+    });
+  });
+});

--- a/tests/integration/order-authorization.scenario.test.ts
+++ b/tests/integration/order-authorization.scenario.test.ts
@@ -1,0 +1,192 @@
+import request from 'supertest';
+import { app } from '../../src/app';
+import { clearDatabase, disconnectDatabase, ensureGradeExists } from '../helpers/test-db';
+import prisma from '../../src/lib/prisma';
+
+/**
+ * 시나리오: 주문 권한 테스트
+ *
+ * 1. 두 명의 구매자 회원가입 & 로그인
+ * 2. 구매자 A가 주문 생성
+ * 3. 구매자 B가 A의 주문 조회 시도 (403)
+ * 4. 구매자 B가 A의 주문 수정 시도 (403)
+ * 5. 구매자 B가 A의 주문 삭제 시도 (403)
+ */
+describe('주문 권한 테스트 시나리오', () => {
+  let buyerAToken: string;
+  let buyerBToken: string;
+  let sellerId: string;
+  let storeId: string;
+  let productId: string;
+  let sizeId: number;
+  let orderIdA: string;
+
+  beforeAll(async () => {
+    await clearDatabase();
+    await ensureGradeExists();
+
+    // 판매자 생성
+    const sellerSignupRes = await request(app).post('/api/users').send({
+      email: 'seller@test.com',
+      password: 'TestPassword123!',
+      name: '판매자',
+      type: 'SELLER',
+    });
+    sellerId = sellerSignupRes.body.id;
+
+    // 스토어 생성
+    const store = await prisma.store.create({
+      data: {
+        name: '테스트 스토어',
+        address: '서울시 강남구',
+        phoneNumber: '02-1234-5678',
+        content: '테스트용 스토어입니다',
+        userId: sellerId,
+      },
+    });
+    storeId = store.id;
+
+    // Size 생성 또는 가져오기
+    let size = await prisma.size.findFirst({
+      where: { en: 'L' },
+    });
+    if (!size) {
+      size = await prisma.size.create({
+        data: { en: 'L', ko: 'L' },
+      });
+    }
+    sizeId = size.id;
+
+    // 상품 생성
+    const product = await prisma.product.create({
+      data: {
+        name: '테스트 상품',
+        content: '주문 권한 테스트용 상품',
+        price: 30000,
+        categoryName: 'BOTTOM',
+        storeId: storeId,
+        image: 'https://fake-s3-url.com/product.jpg',
+      },
+    });
+    productId = product.id;
+
+    // 재고 생성
+    await prisma.stock.create({
+      data: {
+        productId: productId,
+        sizeId: sizeId,
+        quantity: 50,
+      },
+    });
+
+    // 1. 구매자 A 회원가입 & 로그인
+    await request(app).post('/api/users').send({
+      email: 'buyerA@test.com',
+      password: 'TestPassword123!',
+      name: '구매자A',
+      type: 'BUYER',
+    });
+
+    const buyerALoginRes = await request(app).post('/api/auth/login').send({
+      email: 'buyerA@test.com',
+      password: 'TestPassword123!',
+    });
+    buyerAToken = buyerALoginRes.body.accessToken;
+
+    // 구매자 B 회원가입 & 로그인
+    await request(app).post('/api/users').send({
+      email: 'buyerB@test.com',
+      password: 'TestPassword123!',
+      name: '구매자B',
+      type: 'BUYER',
+    });
+
+    const buyerBLoginRes = await request(app).post('/api/auth/login').send({
+      email: 'buyerB@test.com',
+      password: 'TestPassword123!',
+    });
+    buyerBToken = buyerBLoginRes.body.accessToken;
+  });
+
+  afterAll(async () => {
+    await clearDatabase();
+    await disconnectDatabase();
+  });
+
+  it('구매자 A가 주문 생성 → 구매자 B가 A의 주문 조회/수정/삭제 시도 시 403 에러', async () => {
+    // 2. 구매자 A가 주문 생성
+    const createOrderRes = await request(app)
+      .post('/api/orders')
+      .set('Authorization', `Bearer ${buyerAToken}`)
+      .send({
+        name: '구매자A',
+        phone: '0101111-2222',
+        address: '서울시 강남구 테헤란로 111',
+        orderItems: [
+          {
+            productId: productId,
+            sizeId: sizeId,
+            quantity: 1,
+          },
+        ],
+        usePoint: 0,
+      });
+
+    expect(createOrderRes.status).toBe(201);
+    orderIdA = createOrderRes.body.id;
+
+    // 3. 구매자 B가 A의 주문 조회 시도 (403)
+    const getOrderRes = await request(app)
+      .get(`/api/orders/${orderIdA}`)
+      .set('Authorization', `Bearer ${buyerBToken}`);
+
+    expect(getOrderRes.status).toBe(403);
+
+    // 4. 구매자 B가 A의 주문 수정 시도 (403)
+    const updateOrderRes = await request(app)
+      .patch(`/api/orders/${orderIdA}`)
+      .set('Authorization', `Bearer ${buyerBToken}`)
+      .send({
+        name: '구매자B',
+        phone: '0113333-4444',
+        address: '서울시 서초구',
+        orderItems: [
+          {
+            productId: productId,
+            sizeId: sizeId,
+            quantity: 2,
+          },
+        ],
+        usePoint: 0,
+      });
+
+    expect(updateOrderRes.status).toBe(403);
+
+    // 5. 구매자 B가 A의 주문 삭제 시도 (403)
+    const deleteOrderRes = await request(app)
+      .delete(`/api/orders/${orderIdA}`)
+      .set('Authorization', `Bearer ${buyerBToken}`);
+
+    expect(deleteOrderRes.status).toBe(403);
+
+    // 검증: 구매자 A는 여전히 자신의 주문을 조회할 수 있어야 함
+    const verifyOrderRes = await request(app)
+      .get(`/api/orders/${orderIdA}`)
+      .set('Authorization', `Bearer ${buyerAToken}`);
+
+    expect(verifyOrderRes.status).toBe(200);
+    expect(verifyOrderRes.body.id).toBe(orderIdA);
+  });
+
+  it('인증 없이 주문 목록 조회 시도 시 401 에러', async () => {
+    const res = await request(app).get('/api/orders');
+
+    expect(res.status).toBe(401);
+  });
+
+  it('인증 없이 주문 상세 조회 시도 시 401 에러', async () => {
+    const res = await request(app).get(`/api/orders/${orderIdA}`);
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/integration/order-lifecycle.scenario.test.ts
+++ b/tests/integration/order-lifecycle.scenario.test.ts
@@ -1,0 +1,263 @@
+import request from 'supertest';
+import { app } from '../../src/app';
+import { clearDatabase, disconnectDatabase, ensureGradeExists } from '../helpers/test-db';
+import prisma from '../../src/lib/prisma';
+
+/**
+ * 시나리오: 오더
+ *
+ * 1. 판매자 회원가입 & 로그인
+ *    POST /api/users
+ *    POST /api/auth/login
+ *
+ * 2. 판매자가 스토어 & 상품 생성 (DB 직접)
+ *
+ * 3. 구매자 회원가입 & 로그인
+ *    POST /api/users
+ *    POST /api/auth/login
+ *
+ * 4. 주문 생성
+ *    POST /api/orders
+ *
+ * 5. 주문 목록 조회
+ *    GET /api/orders
+ *
+ * 6. 주문 상세 조회
+ *    GET /api/orders/:orderId
+ *
+ * 7. 주문 정보 수정
+ *    PATCH /api/orders/:orderId
+ *
+ * 8. 주문 삭제
+ *    DELETE /api/orders/:orderId
+ */
+describe('주문 생명주기 시나리오', () => {
+  let buyerToken: string;
+  let sellerId: string;
+  let storeId: string;
+  let productId: string;
+  let sizeId: number;
+  let orderId: string;
+
+  beforeAll(async () => {
+    await clearDatabase();
+    await ensureGradeExists();
+
+    // 1. 판매자 회원가입 & 로그인
+    const sellerSignupRes = await request(app).post('/api/users').send({
+      email: 'seller@test.com',
+      password: 'TestPassword123!',
+      name: '판매자',
+      type: 'SELLER',
+    });
+    sellerId = sellerSignupRes.body.id;
+
+    // 2. 판매자가 스토어 & 상품 생성 (DB 직접)
+    const store = await prisma.store.create({
+      data: {
+        name: '테스트 스토어',
+        address: '서울시 강남구',
+        phoneNumber: '02-1234-5678',
+        content: '테스트용 스토어입니다',
+        userId: sellerId,
+      },
+    });
+    storeId = store.id;
+
+    // Size 생성 또는 가져오기
+    let size = await prisma.size.findFirst({
+      where: { en: 'M' },
+    });
+    if (!size) {
+      size = await prisma.size.create({
+        data: { en: 'M', ko: 'M' },
+      });
+    }
+    sizeId = size.id;
+
+    const product = await prisma.product.create({
+      data: {
+        name: '테스트 상품',
+        content: '주문 테스트용 상품입니다',
+        price: 50000,
+        categoryName: 'TOP',
+        storeId: storeId,
+        image: 'https://fake-s3-url.com/product.jpg',
+      },
+    });
+    productId = product.id;
+
+    // 재고 생성
+    await prisma.stock.create({
+      data: {
+        productId: productId,
+        sizeId: sizeId,
+        quantity: 100,
+      },
+    });
+
+    // 3. 구매자 회원가입 & 로그인
+    await request(app).post('/api/users').send({
+      email: 'buyer@test.com',
+      password: 'TestPassword123!',
+      name: '구매자',
+      type: 'BUYER',
+    });
+
+    const buyerLoginRes = await request(app).post('/api/auth/login').send({
+      email: 'buyer@test.com',
+      password: 'TestPassword123!',
+    });
+    buyerToken = buyerLoginRes.body.accessToken;
+  });
+
+  afterAll(async () => {
+    await clearDatabase();
+    await disconnectDatabase();
+  });
+
+  it('주문 생성 → 목록 조회 → 상세 조회', async () => {
+    // 4. 주문 생성
+    const createOrderRes = await request(app)
+      .post('/api/orders')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({
+        name: '구매자',
+        phone: '0101234-5678',
+        address: '서울시 강남구 테헤란로 123',
+        orderItems: [
+          {
+            productId: productId,
+            sizeId: sizeId,
+            quantity: 2,
+          },
+        ],
+        usePoint: 0,
+      });
+
+    expect(createOrderRes.status).toBe(201);
+    expect(createOrderRes.body).toHaveProperty('id');
+    expect(createOrderRes.body.name).toBe('구매자');
+    orderId = createOrderRes.body.id;
+
+    // 5. 주문 목록 조회
+    const getOrdersRes = await request(app)
+      .get('/api/orders?page=1&limit=10')
+      .set('Authorization', `Bearer ${buyerToken}`);
+
+    expect(getOrdersRes.status).toBe(200);
+    expect(getOrdersRes.body).toHaveProperty('data');
+    expect(Array.isArray(getOrdersRes.body.data)).toBe(true);
+    expect(getOrdersRes.body.data.length).toBeGreaterThan(0);
+
+    // 6. 주문 상세 조회
+    const getOrderDetailRes = await request(app)
+      .get(`/api/orders/${orderId}`)
+      .set('Authorization', `Bearer ${buyerToken}`);
+
+    expect(getOrderDetailRes.status).toBe(200);
+    expect(getOrderDetailRes.body.id).toBe(orderId);
+    expect(getOrderDetailRes.body).toHaveProperty('orderItems');
+    expect(Array.isArray(getOrderDetailRes.body.orderItems)).toBe(true);
+  });
+
+  it('결제 완료된 주문 수정/삭제 시도 시 400 에러', async () => {
+    // 주문 생성 (자동으로 CompletedPayment 상태가 됨)
+    const createOrderRes = await request(app)
+      .post('/api/orders')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({
+        name: '구매자',
+        phone: '0101234-5678',
+        address: '서울시 강남구',
+        orderItems: [
+          {
+            productId: productId,
+            sizeId: sizeId,
+            quantity: 1,
+          },
+        ],
+        usePoint: 0,
+      });
+
+    const orderId = createOrderRes.body.id;
+
+    // 결제 완료된 주문 수정 시도
+    const updateOrderRes = await request(app)
+      .patch(`/api/orders/${orderId}`)
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({
+        name: '구매자수정',
+        phone: '0119876-5432',
+        address: '서울시 서초구',
+        orderItems: [
+          {
+            productId: productId,
+            sizeId: sizeId,
+            quantity: 2,
+          },
+        ],
+        usePoint: 0,
+      });
+
+    expect(updateOrderRes.status).toBe(400);
+    expect(updateOrderRes.body.message).toContain('결제 대기 상태');
+
+    // 결제 완료된 주문 삭제 시도
+    const deleteOrderRes = await request(app)
+      .delete(`/api/orders/${orderId}`)
+      .set('Authorization', `Bearer ${buyerToken}`);
+
+    expect(deleteOrderRes.status).toBe(400);
+    expect(deleteOrderRes.body.message).toContain('결제 대기 상태');
+  });
+
+  it('인증 없이 주문 생성 시도 시 401 에러', async () => {
+    const res = await request(app)
+      .post('/api/orders')
+      .send({
+        name: '구매자',
+        phone: '0101234-5678',
+        address: '서울시 강남구',
+        orderItems: [
+          {
+            productId: productId,
+            sizeId: sizeId,
+            quantity: 1,
+          },
+        ],
+        usePoint: 0,
+      });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('잘못된 orderId로 조회 시 404 에러', async () => {
+    const res = await request(app)
+      .get('/api/orders/invalid-order-id')
+      .set('Authorization', `Bearer ${buyerToken}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('주문 생성 시 유효하지 않은 전화번호 형식으로 400 에러', async () => {
+    const res = await request(app)
+      .post('/api/orders')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({
+        name: '구매자',
+        phone: '잘못된형식', // 잘못된 형식
+        address: '서울시 강남구',
+        orderItems: [
+          {
+            productId: productId,
+            sizeId: sizeId,
+            quantity: 1,
+          },
+        ],
+        usePoint: 0,
+      });
+
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## 📌 Related Issue

- #152 
- #154 

## 🧾 작업 사항
```
/**
 * 시나리오: 대시보드 조회 테스트
 *
 * 1. 판매자 회원가입 & 로그인
 *    POST /api/users
 *    POST /api/auth/login
 *
 * 2. 판매자가 스토어 & 상품 생성 (DB 직접)
 *
 * 3. 구매자 회원가입 & 주문 생성 (DB 직접)
 *
 * 4. 판매자가 대시보드 조회
 *    GET /api/dashboard
 *
 * 5. 구매자가 대시보드 조회 시도 (403 에러)
 */
 
 /**
 * 시나리오: 오더 권한 테스트
 *
 * 1. 두 명의 구매자 회원가입 & 로그인
 * 2. 구매자 A가 주문 생성
 * 3. 구매자 B가 A의 주문 조회 시도 (403)
 * 4. 구매자 B가 A의 주문 수정 시도 (403)
 * 5. 구매자 B가 A의 주문 삭제 시도 (403)
 */

/**
 * 시나리오: 오더
 *
 * 1. 판매자 회원가입 & 로그인
 *    POST /api/users
 *    POST /api/auth/login
 *
 * 2. 판매자가 스토어 & 상품 생성 (DB 직접)
 *
 * 3. 구매자 회원가입 & 로그인
 *    POST /api/users
 *    POST /api/auth/login
 *
 * 4. 주문 생성
 *    POST /api/orders
 *
 * 5. 주문 목록 조회
 *    GET /api/orders
 *
 * 6. 주문 상세 조회
 *    GET /api/orders/:orderId
 *
 * 7. 주문 정보 수정
 *    PATCH /api/orders/:orderId
 *
 * 8. 주문 삭제
 *    DELETE /api/orders/:orderId
 */
```
- 대시보드랑 오더 시나리오기반 통합테스트입니다